### PR TITLE
Fix error in issue #21

### DIFF
--- a/packages/core/src/use-map-animate-to-style.ts
+++ b/packages/core/src/use-map-animate-to-style.ts
@@ -254,9 +254,9 @@ export default function useMapAnimateToStyle<Animate>({
 
     let mergedStyles: Animate = {} as Animate
     if (stylePriority === 'state') {
-      mergedStyles = Object.assign(animateStyle, variantStyle)
+      mergedStyles = Object.assign({}, animateStyle, variantStyle)
     } else {
-      mergedStyles = Object.assign(variantStyle, animateStyle)
+      mergedStyles = Object.assign({}, variantStyle, animateStyle)
     }
 
     if (isExiting && exitStyle) {
@@ -376,7 +376,7 @@ export default function useMapAnimateToStyle<Animate>({
               } = animationConfig(key, transition)
 
 
-              // stepConfig = Object.assign(stepConfig, customConfig)
+              // stepConfig = Object.assign({}, stepConfig, customConfig)
 
               stepAnimation = animation
               if (delay != null) {

--- a/packages/core/src/use-map-animate-to-style.ts
+++ b/packages/core/src/use-map-animate-to-style.ts
@@ -254,9 +254,9 @@ export default function useMapAnimateToStyle<Animate>({
 
     let mergedStyles: Animate = {} as Animate
     if (stylePriority === 'state') {
-      mergedStyles = { ...animateStyle, ...variantStyle }
+      mergedStyles = Object.assign(animateStyle, variantStyle)
     } else {
-      mergedStyles = { ...variantStyle, ...animateStyle }
+      mergedStyles = Object.assign(variantStyle, animateStyle)
     }
 
     if (isExiting && exitStyle) {

--- a/packages/core/src/use-map-animate-to-style.ts
+++ b/packages/core/src/use-map-animate-to-style.ts
@@ -360,7 +360,7 @@ export default function useMapAnimateToStyle<Animate>({
           .map((step) => {
             let stepDelay = delayMs
             let stepValue = step
-            let stepConfig = { ...config }
+            let stepConfig = Object.assign({}, config)
             let stepAnimation = animation
             if (typeof step === 'object') {
               // TODO this should spread from step, but reanimated won't allow this on JS thread?
@@ -375,10 +375,9 @@ export default function useMapAnimateToStyle<Animate>({
                 animation,
               } = animationConfig(key, transition)
 
-              stepConfig = {
-                ...stepConfig,
-                //  ...customConfig
-              }
+
+              // stepConfig = Object.assign(stepConfig, customConfig)
+
               stepAnimation = animation
               if (delay != null) {
                 stepDelay = delay


### PR DESCRIPTION
Fixing this issue: https://github.com/nandorojo/moti/issues/21 regarding "Tried to synchronously call function {assign} from a different thread." 

It turns out the object spread does not work correctly in worklets, using regular object assign fixing the error. 

