### PR TITLE
Fix coding style in Exit Before Enter example page

### DIFF
--- a/docs/docs/examples/exit-before-enter.md
+++ b/docs/docs/examples/exit-before-enter.md
@@ -43,8 +43,7 @@ export default function ExitBeforeEnter() {
   return (
     <Pressable onPress={toggle} style={styles.container}>
       <AnimatePresence exitBeforeEnter>
-        {visible && <Shape bg="hotpink" key="hotpink" />}
-        {!visible && <Shape bg="cyan" key="cyan" />}
+        {visible ? <Shape bg="hotpink" key="hotpink" /> : <Shape bg="cyan" key="cyan" />}
       </AnimatePresence>
     </Pressable>
   )

--- a/docs/docs/examples/exit-before-enter.md
+++ b/docs/docs/examples/exit-before-enter.md
@@ -43,7 +43,10 @@ export default function ExitBeforeEnter() {
   return (
     <Pressable onPress={toggle} style={styles.container}>
       <AnimatePresence exitBeforeEnter>
-        {visible ? <Shape bg="hotpink" key="hotpink" /> : <Shape bg="cyan" key="cyan" />}
+        { visible ? 
+          <Shape bg="hotpink" key="hotpink" /> 
+          : 
+          <Shape bg="cyan" key="cyan" /> }
       </AnimatePresence>
     </Pressable>
   )


### PR DESCRIPTION
I think it is a better practice to use ternary operators in conditional rendering.