### PR TITLE
Fix setting `repeatReverse = false`

### DIFF
--- a/packages/core/src/use-map-animate-to-style.ts
+++ b/packages/core/src/use-map-animate-to-style.ts
@@ -104,7 +104,7 @@ function animationConfig<Animate>(
 
   if ((transition as any)?.[key as keyof Animate]?.repeatReverse != null) {
     repeatReverse = (transition as any)?.[key as keyof Animate]?.repeatReverse
-  } else if (transition?.repeatReverse) {
+  } else if (transition?.repeatReverse != null) {
     repeatReverse = transition.repeatReverse
   }
 


### PR DESCRIPTION
Needs a null check here otherwise Moti wont pickup `repeatReverse = false` in the transition config.