### PR TITLE
remove typescript flag -t

### DIFF
--- a/docs/docs/starter.md
+++ b/docs/docs/starter.md
@@ -7,7 +7,7 @@ sidebar_label: Starter Project
 If you're starting a project from scratch, or just want to play around, you can use the Expo + Moti [starter template](https://github.com/expo/examples/tree/master/with-moti).
 
 ```sh
-npx create-react-native-app -t with-moti
+npx create-react-native-app with-moti
 ```
 
 Thanks to Evan Bacon for making that!


### PR DESCRIPTION
$ npx create-react-native-app -t with-moti
cli response: Usage: create-react-native-app <project-directory> [--verbose]

With -t flag does not enable project initialise, without -t flag enables to initialise, then select template choice including with or without typescript