### PR TITLE
Update next.config.js docs to suggest transpiling @motify/core instead

### DIFF
--- a/docs/docs/next-js.md
+++ b/docs/docs/next-js.md
@@ -25,7 +25,7 @@ const withPlugins = require('next-compose-plugins')
 
 const withTM = require('next-transpile-modules')([
   'moti',
-  '@motify',
+  '@motify/core',
   // you can add other modules that need traspiling here
 ])
 


### PR DESCRIPTION
Attempting to transpile in `next.config.js` as suggested in the docs causes errors:

<img width="1316" alt="Screenshot 2021-05-04 at 08 16 13" src="https://user-images.githubusercontent.com/5967956/116967263-321f4b80-acb2-11eb-870d-3f1414a5f834.png">

Changing this to `@motify/core` instead seems to solve the issue though