### PR TITLE
(docs): Replace usage of `<View>` with `<MotiView>`

### DIFF
--- a/docs/docs/animations-overview.md
+++ b/docs/docs/animations-overview.md
@@ -6,7 +6,7 @@ title: Overview
 Moti has a number of powerful features that make your animations slick and simple.
 
 ```ts
-import { View, Text } from 'moti'
+import { MotiView, Text } from 'moti'
 ```
 
 ## Mount animations
@@ -14,13 +14,13 @@ import { View, Text } from 'moti'
 You can set the initial state with `from`. Any styles passed to `animate` will transition for you.
 
 ```tsx
-<View from={{ opacity: 0 }} animate={{ opacity: 1 }} />
+<MotiView from={{ opacity: 0 }} animate={{ opacity: 1 }} />
 ```
 
 ## Animate based on React state
 
 ```tsx
-<View animate={{ opacity: isLoading ? 1 : 0 }} />
+<MotiView animate={{ opacity: isLoading ? 1 : 0 }} />
 ```
 
 This is useful for dynamic height changes, for instance.
@@ -28,7 +28,7 @@ This is useful for dynamic height changes, for instance.
 ```tsx
 const [height, setHeight] = useMeasure()
 
-<View
+<MotiView
   animate={{
     height,
   }}
@@ -40,7 +40,7 @@ const [height, setHeight] = useMeasure()
 Moti animations are highly configurable, thanks to the `transition` prop. If you've used `framer-motion`, this will look familiar.
 
 ```tsx
-<View
+<MotiView
   from={{ opacity: 0, scale: 0.5 }}
   animate={{ opacity: 1, scale: 1 }}
   transition={{
@@ -53,7 +53,7 @@ Moti animations are highly configurable, thanks to the `transition` prop. If you
 You can also configure different transitions per-style:
 
 ```tsx
-<View
+<MotiView
   from={{ opacity: 0, scale: 0.5 }}
   animate={{ opacity: 1, scale: 1 }}
   transition={{
@@ -92,7 +92,7 @@ const [visible, setVisible] = useState(false)
 
 <AnimatePresence>
   {visible && (
-    <View
+    <MotiView
       from={{ opacity: 1 }}
       animate={{ opacity: 1 }}
       exit={{
@@ -113,7 +113,7 @@ Make sure that its direct children have a unique `key` prop for this to work.
 
 ```tsx
 const Skeleton = () => (
-  <View
+  <MotiView
     animate={{ opacity: 1 }}
     exit={{
       opacity: 0,
@@ -126,7 +126,7 @@ const WithAnimatedPresence = () => (
     {loading && <Skeleton key="skeleton" />}
 
     {!loading && (
-      <View
+      <MotiView
         key="content"
         animate={{ opacity: 1 }}
         exit={{
@@ -147,7 +147,7 @@ The `exit` prop can be inside of a nested component. However, it's important tha
 You can use the `delay` prop
 
 ```tsx
-<View
+<MotiView
   // delay in milliseconds
   delay={200}
   from={{ translateY: -5 }}
@@ -158,7 +158,7 @@ You can use the `delay` prop
 Or, pass your `delay` in `transition`:
 
 ```tsx
-<View
+<MotiView
   from={{ translateY: -5 }}
   animate={{ translateY: 0 }}
   transition={{
@@ -170,7 +170,7 @@ Or, pass your `delay` in `transition`:
 You can also set a different delay per-style:
 
 ```tsx
-<View
+<MotiView
   from={{ translateY: -5, opacity: 0 }}
   animate={{ translateY: 0, opacity: 1 }}
   transition={{
@@ -189,7 +189,7 @@ You can also set a different delay per-style:
 To create a sequence animation, similar to CSS keyframes, just pass an array to any style:
 
 ```tsx
-<View
+<MotiView
   animate={{
     scale: [0.1, 1.1, 1],
   }}
@@ -201,7 +201,7 @@ This will animate to `0.1`, then `1.1`, then `1`.
 If you want to customize each step of the animation, you can also pass an object with a `value` field.
 
 ```tsx
-<View
+<MotiView
   animate={{
     scale: [
       // you can mix primitive values with objects, too
@@ -220,7 +220,7 @@ Any `transition` settings can be passed to a sequence object.
 Repeat an animation 4 times.
 
 ```tsx
-<View
+<MotiView
   from={{ opacity: 0 }}
   animate={{ opacity: 1 }}
   transition={{
@@ -234,7 +234,7 @@ By default, repetitions reverse, meaning they automatically animate back to wher
 You can disable this behavior with `repeatReverse: false`.
 
 ```tsx
-<View
+<MotiView
   from={{ opacity: 0 }}
   animate={{ opacity: 1 }}
   transition={{
@@ -250,7 +250,7 @@ Setting `repeatReverse` to `true` is like setting `animationDirection: alternate
 Infinitely loop from 0 to 1:
 
 ```tsx
-<View
+<MotiView
   from={{ opacity: 0 }}
   animate={{ opacity: 1 }}
   transition={{
@@ -268,7 +268,7 @@ Repetition styles can't be changed on the fly. Reanimated's `withRepeat` has som
 The `onDidAnimate` function prop gets called whenever an animation completes.
 
 ```tsx
-<View
+<MotiView
   from={{ opacity: 0 }}
   animate={{ opacity: 1 }}
   onDidAnimate={(
@@ -301,7 +301,7 @@ const animationState = useAnimationState({
 })
 
 // make sure to pass this to the `state` prop
-return <View state={animationState} />
+return <MotiView state={animationState} />
 ```
 
 Or set custom variants and update them on the fly:
@@ -324,7 +324,7 @@ const onPress = () => {
   }
 }
 
-return <View state={animationState} />
+return <MotiView state={animationState} />
 ```
 
 You can use this to create reusable animations, too:
@@ -344,7 +344,7 @@ const useFadeIn = () => {
 const FadeInComponent = () => {
   const fadeInState = useFadeIn()
 
-  return <View state={fadeInState} />
+  return <MotiView state={fadeInState} />
 }
 ```
 

--- a/docs/docs/api/transforms.md
+++ b/docs/docs/api/transforms.md
@@ -9,7 +9,7 @@ Rather than using a `transform` array, we pass the values directly:
 
 ```tsx
 // ✅ pass scale, translateY directly
-<View
+<MotiView
   animate={{
     scale: 1,
     translateY: 5,
@@ -19,7 +19,7 @@ Rather than using a `transform` array, we pass the values directly:
 
 ```tsx
 // 🚨 not this
-<View
+<MotiView
   animate={{
     transform: [{ scale: 1 }, { translateY: 5 }],
   }}

--- a/docs/docs/api/use-animation-state.md
+++ b/docs/docs/api/use-animation-state.md
@@ -33,7 +33,7 @@ const onPress = () => {
   }
 }
 
-return <View state={animationState} />
+return <MotiView state={animationState} />
 ```
 
 ### When to use this
@@ -47,7 +47,7 @@ When using this hook, your animations are static, meaning they have to be known 
 ### Import
 
 ```ts
-import { View, useAnimationState } from 'moti'
+import { MotiView, useAnimationState } from 'moti'
 ```
 
 Moti exports typical `react-native` components, such as `View`, `Text`, etc.
@@ -70,7 +70,7 @@ const animationState = useAnimationState({
 ### Pass state to your Moti component
 
 ```tsx
-<View state={animationState} />
+<MotiView state={animationState} />
 ```
 
 Create your `animationState`, and pass it as your moti component's `state` prop.
@@ -101,7 +101,7 @@ return (
       animationState.transitionTo('active')
     }}
   >
-    <View style={styles.shape} state={animationState} />
+    <MotiView style={styles.shape} state={animationState} />
   </Pressable>
 )
 ```
@@ -136,7 +136,7 @@ return (
       })
     }}
   >
-    <View style={styles.shape} state={animationState} />
+    <MotiView style={styles.shape} state={animationState} />
   </Pressable>
 )
 ```
@@ -182,7 +182,7 @@ return (
       })
     }}
   >
-    <View style={styles.shape} state={animationState} />
+    <MotiView style={styles.shape} state={animationState} />
   </Pressable>
 )
 ```
@@ -191,7 +191,7 @@ return (
 
 ```tsx
 import React from 'react'
-import { useAnimationState, View } from 'moti'
+import { useAnimationState, MotiView } from 'moti'
 import { StyleSheet } from 'react-native'
 
 export default function PerformantView() {
@@ -206,7 +206,7 @@ export default function PerformantView() {
     },
   })
 
-  return <View style={styles.shape} state={animationState} />
+  return <MotiView style={styles.shape} state={animationState} />
 }
 
 const styles = StyleSheet.create({
@@ -232,7 +232,7 @@ const animationState = useAnimationState({
   },
 })
 
-return <View state={animationState} />
+return <MotiView state={animationState} />
 ```
 
 If both `from` and `to` are set, then it will transition from one to the other on the component's initial mount. If only `from` is set, this will be the initial state.
@@ -243,7 +243,7 @@ If you don't want mount animations, give your variants different names.
 ## Example
 
 ```jsx
-import { useAnimationState, View } from 'moti'
+import { useAnimationState, MotiView } from 'moti'
 
 const animator = useAnimationState({
   from: {
@@ -259,7 +259,7 @@ const animator = useAnimationState({
 
 return (
   <>
-    <View state={animator} style={{ height: 100 }} />
+    <MotiView state={animator} style={{ height: 100 }} />
     <Button
       title="Change!"
       onPressIn={() => {
@@ -276,7 +276,7 @@ You can also access the `current` state:
 ```jsx
 import React from 'react'
 import { Button } from 'react-native'
-import  as Moti from 'moti'
+import * as Moti from 'moti'
 
 const animator = Moti.useAnimationState({
   from: {
@@ -426,12 +426,12 @@ const state = useAnimationState({
   },
 })
 
-return <View state={state} />
+return <MotiView state={state} />
 ```
 
 ```jsx
 // ✅ do this instead
-<View animate={{ opacity: isLoading ? 1 : 0 }} />
+<MotiView animate={{ opacity: isLoading ? 1 : 0 }} />
 ```
 
 `useAnimationState` should _only_ be used for **static** variants, meaning the different potential states you'll be animating to will be known ahead of time.

--- a/docs/docs/examples/animate-presence.md
+++ b/docs/docs/examples/animate-presence.md
@@ -9,11 +9,11 @@ See a video of this example [here](https://twitter.com/FernandoTheRojo/status/13
 import React, { useReducer } from 'react'
 import { StyleSheet, Pressable } from 'react-native'
 
-import { View, AnimatePresence } from 'moti'
+import { MotiView, AnimatePresence } from 'moti'
 
 function Shape() {
   return (
-    <View
+    <MotiView
       from={{
         opacity: 0,
         scale: 0.9,

--- a/docs/docs/examples/auto-height.md
+++ b/docs/docs/examples/auto-height.md
@@ -7,7 +7,7 @@ Animate changes in variable height. You can see a video of this example [here](h
 
 ```tsx
 import React, { ComponentProps, useReducer, useState } from 'react'
-import { View as MotiView } from 'moti'
+import { MotiView } from 'moti'
 import { Button, View } from 'react-native'
 
 function useLayout() {

--- a/docs/docs/examples/exit-before-enter.md
+++ b/docs/docs/examples/exit-before-enter.md
@@ -15,11 +15,11 @@ See a video of this example [here](https://twitter.com/FernandoTheRojo/status/13
 import { AnimatePresence } from 'framer-motion'
 import React, { useReducer } from 'react'
 import { StyleSheet, Pressable } from 'react-native'
-import { View } from 'moti'
+import { MotiView } from 'moti'
 
 function Shape({ bg }: { bg: string }) {
   return (
-    <View
+    <MotiView
       from={{
         opacity: 0,
         scale: 0.5,

--- a/docs/docs/examples/hello-world.md
+++ b/docs/docs/examples/hello-world.md
@@ -8,11 +8,11 @@ This is all it takes to create an animation that fades and scales in with Moti:
 ```tsx
 import React, { useReducer } from 'react'
 import { StyleSheet, Pressable } from 'react-native'
-import { View } from 'moti'
+import { MotiView } from 'moti'
 
 function Shape() {
   return (
-    <View
+    <MotiView
       from={{
         opacity: 0,
         scale: 0.5,

--- a/docs/docs/examples/loop.md
+++ b/docs/docs/examples/loop.md
@@ -6,7 +6,7 @@ title: Loop Animation
 Create a loop animation of a box that goes up and down infinitely.
 
 :::tip
-Loop animations cannot be changed on the fly. If you want to restart a loop, you need to update a component's `key` prop. 
+Loop animations cannot be changed on the fly. If you want to restart a loop, you need to update a component's `key` prop.
 
 See the explanation at the bottom.
 :::
@@ -16,11 +16,11 @@ See the explanation at the bottom.
 ```tsx
 import React, { useReducer } from 'react'
 import { StyleSheet } from 'react-native'
-import { View } from 'moti'
+import { MotiView } from 'moti'
 
 function Shape() {
   return (
-    <View
+    <MotiView
       from={{
         translateY: -100,
       }}
@@ -40,9 +40,9 @@ function Shape() {
 
 export default function Loop() {
   return (
-    <View style={styles.container}>
+    <MotiView style={styles.container}>
       <Shape />
-    </View>
+    </MotiView>
   )
 }
 

--- a/docs/docs/examples/variants.md
+++ b/docs/docs/examples/variants.md
@@ -8,7 +8,7 @@ Variants are a common use case for animations. Moti makes this easy.
 ```tsx
 import React from 'react'
 import { StyleSheet, Pressable } from 'react-native'
-import { View, useAnimationState } from 'moti'
+import { MotiView, useAnimationState } from 'moti'
 
 // you can create a reusable animation preset
 const useFadeInDown = () => {
@@ -59,8 +59,8 @@ function Shape() {
 
   return (
     <Pressable onPress={onPress}>
-      <View delay={300} state={fadeInDown} style={styles.shape} />
-      <View
+      <MotiView delay={300} state={fadeInDown} style={styles.shape} />
+      <MotiView
         transition={{
           type: 'spring',
         }}
@@ -74,9 +74,9 @@ function Shape() {
 
 export default function Variants() {
   return (
-    <View style={styles.container}>
+    <MotiView style={styles.container}>
       <Shape />
-    </View>
+    </MotiView>
   )
 }
 

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -24,7 +24,7 @@ slug: /
 Moti is the universal animation package for React Native, made by [Fernando Rojo](https://twitter.com/fernandotherojo).
 
 ```tsx
-<View
+<MotiView
   from={{ opacity: 0 }}
   animate={{ opacity: 1 }}
   exit={{

--- a/docs/docs/skeleton.mdx
+++ b/docs/docs/skeleton.mdx
@@ -162,10 +162,10 @@ Here's the code from the video above:
 ```tsx
 import React, { useReducer } from 'react'
 import { StyleSheet, Pressable } from 'react-native'
-import { View } from 'moti'
+import { MotiView } from 'moti'
 import { Skeleton } from '@motify/skeleton'
 
-const Spacer = ({ height = 16 }) => <View style={{ height }} />
+const Spacer = ({ height = 16 }) => <MotiView style={{ height }} />
 
 const transition = {
   opacity: {
@@ -180,7 +180,7 @@ export default function HelloWorld() {
 
   return (
     <Pressable onPress={toggle} style={styles.container}>
-      <View
+      <MotiView
         transition={{
           type: 'timing',
         }}
@@ -208,7 +208,7 @@ export default function HelloWorld() {
           colorMode={colorMode}
           width={'100%'}
         />
-      </View>
+      </MotiView>
     </Pressable>
   )
 }


### PR DESCRIPTION
Since `MotiView` is now importable directly, replaced all instances of `<View>` with `<MotiView>`