### PR TITLE
Fix misspelled key in onDidAnimate callback

### DIFF
--- a/packages/core/src/use-map-animate-to-style.ts
+++ b/packages/core/src/use-map-animate-to-style.ts
@@ -292,7 +292,7 @@ export default function useMapAnimateToStyle<Animate>({
       ) => {
         if (onDidAnimate) {
           runOnJS(reanimatedOnDidAnimated)(key as any, completed, recentValue, {
-            attempedValue: value,
+            attemptedValue: value,
           })
         }
         if (isExiting) {


### PR DESCRIPTION
Fixes a misspelled key name in the object provided as the last argument to the onDidAnimated callback, making the key name consistent with the spelling in the documentation (where 'attempted' is spelled correctly).