### PR TITLE
@motify/skeleton: Fixes backgroundSize prop not being passed down to AnimatedGradient

### DIFF
--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -109,6 +109,7 @@ export default function Skeleton(props: Props) {
     backgroundColor = colors[0] ??
       colors[1] ??
       baseColors[colorMode]?.secondary,
+    backgroundSize = 6,
     disableExitAnimation,
     transition,
   } = props
@@ -183,6 +184,7 @@ export default function Skeleton(props: Props) {
                 transition || null
               )}`}
               colors={colors}
+              backgroundSize={backgroundSize}
               measuredWidth={measuredWidth}
               transition={transition}
             />
@@ -197,13 +199,14 @@ const AnimatedGradient = React.memo(
   function AnimatedGradient({
     measuredWidth,
     colors,
+    backgroundSize,
     transition = {},
   }: {
     measuredWidth: number
     colors: string[]
+    backgroundSize: number,
     transition?: MotiTransitionProp
   }) {
-    const backgroundSize = 6
 
     return (
       <MotiView


### PR DESCRIPTION
Skeleton accepts a prop backgroundSize that is supposed to change the resolution of the gradient created by the skeleton. This prop was not being passed down and was statically set to 6 inside the AnimatedGradient component. 

This PR moves setting the default value to props and passes the prop down to  AnimatedGradient, fixing issue #112. 

Current functionality remains the same. 