### PR TITLE
feat: pass accessibility props to MotiPressable

### DIFF
--- a/packages/interactions/src/pressable/pressable.tsx
+++ b/packages/interactions/src/pressable/pressable.tsx
@@ -43,6 +43,22 @@ export const MotiPressable = forwardRef<View, MotiPressableProps>(
       id,
       hoveredValue,
       pressedValue,
+      // Accessibility props
+      accessibilityActions,
+      accessibilityElementsHidden,
+      accessibilityHint,
+      accessibilityIgnoresInvertColors,
+      accessibilityLabel,
+      accessibilityLiveRegion,
+      accessibilityRole,
+      accessibilityState,
+      accessibilityValue,
+      accessibilityViewIsModal,
+      accessible,
+      onAccessibilityTap,
+      onAccessibilityAction,
+      onAccessibilityEscape,
+      importantForAccessibility,
     } = props
 
     const _hovered = useSharedValue(false)
@@ -112,6 +128,22 @@ export const MotiPressable = forwardRef<View, MotiPressableProps>(
             style={containerStyle}
             onPress={onPress}
             ref={ref}
+            // Accessibility props
+            accessibilityActions={accessibilityActions}
+            accessibilityElementsHidden={accessibilityElementsHidden}
+            accessibilityHint={accessibilityHint}
+            accessibilityIgnoresInvertColors={accessibilityIgnoresInvertColors}
+            accessibilityLabel={accessibilityLabel}
+            accessibilityLiveRegion={accessibilityLiveRegion}
+            accessibilityRole={accessibilityRole}
+            accessibilityState={accessibilityState}
+            accessibilityValue={accessibilityValue}
+            accessibilityViewIsModal={accessibilityViewIsModal}
+            accessible={accessible}
+            onAccessibilityTap={onAccessibilityTap}
+            onAccessibilityAction={onAccessibilityAction}
+            onAccessibilityEscape={onAccessibilityEscape}
+            importantForAccessibility={importantForAccessibility}
           >
             {child}
           </Pressable>
@@ -131,6 +163,22 @@ export const MotiPressable = forwardRef<View, MotiPressableProps>(
           // TODO there is an added View child here, which Pressable doesn't  have.
           // should we wrap the pressable children too?
           containerStyle={containerStyle}
+          // Accessibility props
+          accessibilityActions={accessibilityActions}
+          accessibilityElementsHidden={accessibilityElementsHidden}
+          accessibilityHint={accessibilityHint}
+          accessibilityIgnoresInvertColors={accessibilityIgnoresInvertColors}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityLiveRegion={accessibilityLiveRegion}
+          accessibilityRole={accessibilityRole}
+          accessibilityState={accessibilityState}
+          accessibilityValue={accessibilityValue}
+          accessibilityViewIsModal={accessibilityViewIsModal}
+          accessible={accessible}
+          onAccessibilityTap={onAccessibilityTap}
+          onAccessibilityAction={onAccessibilityAction}
+          onAccessibilityEscape={onAccessibilityEscape}
+          importantForAccessibility={importantForAccessibility}
         >
           {child}
         </AnimatedTouchable>

--- a/packages/interactions/src/pressable/types.ts
+++ b/packages/interactions/src/pressable/types.ts
@@ -1,6 +1,6 @@
 import type { ComponentProps } from 'react'
 import type { MotiView } from '@motify/components'
-import type { ViewStyle, Insets } from 'react-native'
+import type { ViewStyle, Insets, PressableProps } from 'react-native'
 import type { MotiAnimationProp } from '@motify/core'
 import type Animated from 'react-native-reanimated'
 
@@ -69,4 +69,22 @@ export type MotiPressableProps = {
 } & Pick<
   ComponentProps<typeof MotiView>,
   'children' | 'exit' | 'from' | 'transition' | 'exitTransition' | 'style'
->
+> &
+  Pick<
+    PressableProps,
+    | 'accessibilityActions'
+    | 'accessibilityElementsHidden'
+    | 'accessibilityHint'
+    | 'accessibilityIgnoresInvertColors'
+    | 'accessibilityLabel'
+    | 'accessibilityLiveRegion'
+    | 'accessibilityRole'
+    | 'accessibilityState'
+    | 'accessibilityValue'
+    | 'accessibilityViewIsModal'
+    | 'accessible'
+    | 'onAccessibilityTap'
+    | 'onAccessibilityAction'
+    | 'onAccessibilityEscape'
+    | 'importantForAccessibility'
+  >;


### PR DESCRIPTION
This adds support for Pressable accessibility props on MotiPressable,

It passes the props directly instead of spreading all props from Pressable.

Not sure if selectively excluding specific props from pressable would be a viable/cleaner approach