### PR TITLE
MotiPressable: Changed containerStyle to style on parent element 

### DIFF
--- a/packages/interactions/src/pressable/pressable.tsx
+++ b/packages/interactions/src/pressable/pressable.tsx
@@ -182,7 +182,7 @@ export const MotiPressable = forwardRef<View, MotiPressableProps>(
           // @ts-expect-error incorrect ref types, lol
           ref={ref}
           onLayout={onContainerLayout}
-          containerStyle={containerStyle}
+          style={containerStyle}
           // Accessibility props
           accessibilityActions={accessibilityActions}
           accessibilityElementsHidden={accessibilityElementsHidden}


### PR DESCRIPTION
# Description
Using the `containerStyle` prop on the `AnimatedTouchable` leads to elevation-based shadow not working on Android devices. However, they seem to work when using the `style` prop instead. This change is to meant to fix this.

Fixes: #149 