### PR TITLE
Add `null` type to Skeleton children

### DIFF
--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -16,7 +16,7 @@ type Props = {
    * Optional height of the skeleton. Defauls to a `minHeight` of `32`
    */
   height?: number | string
-  children?: React.ReactChild
+  children?: React.ReactChild | null
   /**
    * `boolean` specifying whether the skeleton should be visible. By default, it shows if there are no children. This way, you can conditionally display children, and automatically hide the skeleton when they exist.
    *


### PR DESCRIPTION
Even though the documentation states that the `Skeleton` component accepts null as a child, typescript linter throws an error.