### PR TITLE
docs: added action menu example

### DIFF
--- a/docs/docs/examples/action-menu.md
+++ b/docs/docs/examples/action-menu.md
@@ -1,0 +1,7 @@
+---
+id: action-menu
+title: Action Menu
+---
+
+<div data-snack-id="@alevy-97/action-menu" data-snack-platform="web" data-snack-preview="true" data-snack-theme="dark" style={{"overflow":"hidden",background:"#212121",border:"1px solid var(--color-border)",borderRadius:"4px",height:"700px",width:"100%"}}></div>
+<script async src="https://snack.expo.dev/embed.js"></script>

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -15,7 +15,7 @@ module.exports = {
       async: true,
     },
     {
-      scrc: 'https://snack.expo.dev/embed',
+      src: 'https://snack.expo.dev/embed',
       async: true,
     },
   ],

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -10,6 +10,7 @@ module.exports = {
       'examples/loop',
       'examples/variants',
       'examples/dropdown',
+      'examples/action-menu',
     ],
     Hooks: ['hooks/use-animation-state', 'hooks/use-dynamic-animation'],
     ['Interactions']: [


### PR DESCRIPTION
Hey I added my example to the docs using an embedded snack. Let me know if this is what you were thinking of. I wasn't able to get `<MotiPressable />` working in the snack unfortunately, but the example is fine without it. 

Also, I think there was a typo in `docusaurus.config.js`, fixed it in here. 

Snack: https://snack.expo.dev/@alevy97/action-menu