### PR TITLE
Docs/fix snack id

### DIFF
--- a/docs/docs/examples/action-menu.md
+++ b/docs/docs/examples/action-menu.md
@@ -3,5 +3,5 @@ id: action-menu
 title: Action Menu
 ---
 
-<div data-snack-id="@alevy-97/action-menu" data-snack-platform="web" data-snack-preview="true" data-snack-theme="dark" style={{"overflow":"hidden",background:"#212121",border:"1px solid var(--color-border)",borderRadius:"4px",height:"700px",width:"100%"}}></div>
+<div data-snack-id="@alevy97/action-menu" data-snack-platform="web" data-snack-preview="true" data-snack-theme="dark" style={{"overflow":"hidden",background:"#212121",border:"1px solid var(--color-border)",borderRadius:"4px",height:"700px",width:"100%"}}></div>
 <script async src="https://snack.expo.dev/embed.js"></script>

--- a/docs/docs/examples/action-menu.md
+++ b/docs/docs/examples/action-menu.md
@@ -3,5 +3,5 @@ id: action-menu
 title: Action Menu
 ---
 
-<div data-snack-id="@alevy97/action-menu" data-snack-platform="web" data-snack-preview="true" data-snack-theme="dark" style={{"overflow":"hidden",background:"#212121",border:"1px solid var(--color-border)",borderRadius:"4px",height:"700px",width:"100%"}}></div>
+<div data-snack-id="@alevy97/action-menu" data-snack-platform="web" data-snack-preview="true" data-snack-theme="dark" style={{height:"700px"}}></div>
 <script async src="https://snack.expo.dev/embed.js"></script>

--- a/docs/docs/examples/exit-before-enter.md
+++ b/docs/docs/examples/exit-before-enter.md
@@ -11,4 +11,5 @@ Also, enable the `exitBeforeEnter` prop.
 
 See a video of this example [here](https://twitter.com/FernandoTheRojo/status/1351234878902333445).
 
-<div data-snack-id="@beatgig/exit-before-enter" data-snack-platform="web" data-snack-preview="true" data-snack-theme="dark" style="overflow:hidden;background:#212121;border:1px solid var(--color-border);border-radius:4px;height:505px;width:100%"></div>
+<div data-snack-id="@beatgig/exit-before-enter" data-snack-platform="web" data-snack-preview="true" data-snack-theme="dark" style={{"overflow":"hidden",background:"#212121",border:"1px solid var(--color-border)",borderRadius:"4px",height:"505px",width:"100%"}}></div>
+<script async src="https://snack.expo.dev/embed.js"></script>

--- a/docs/docs/examples/exit-before-enter.md
+++ b/docs/docs/examples/exit-before-enter.md
@@ -12,3 +12,4 @@ Also, enable the `exitBeforeEnter` prop.
 See a video of this example [here](https://twitter.com/FernandoTheRojo/status/1351234878902333445).
 
 <div data-snack-id="@beatgig/exit-before-enter" data-snack-platform="web" data-snack-preview="true" data-snack-theme="dark"></div>
+<script async src="https://snack.expo.dev/embed.js"></script>


### PR DESCRIPTION
Oops, had a typo in the snack id from my last PR. Fixed it here. 

I also noticed that the snack in https://moti.fyi/examples/exit-before-enter wont load for me, I think it's missing the `embed.js` script. I added that change in this PR as well.