### PR TITLE
docs: proper stackblitz url on exit-before-enter.md

### DIFF
--- a/docs/docs/examples/exit-before-enter.md
+++ b/docs/docs/examples/exit-before-enter.md
@@ -4,4 +4,4 @@ hide_table_of_contents: true
 sidebar_label: Exit Before Enter
 ---
 
-<iframe src="https://stackblitz.com/edit/nextjs-dc1m4i?embed=1&file=README.md" className="stackblitz" />
+<iframe src="https://stackblitz.com/edit/nextjs-dc1m4i?embed=1&file=pages/index.tsx" className="stackblitz" />


### PR DESCRIPTION
previously the link was pointing to README.md