### PR TITLE
Fix typo in use-pressable-transition page

### DIFF
--- a/docs/docs/interactions/use-pressable-transition.md
+++ b/docs/docs/interactions/use-pressable-transition.md
@@ -46,7 +46,7 @@ Then, in the `Item` component:
 
 ```tsx
 const Item = () => {
-  const state = useMotiPressableTransition(({ pressed }) => {
+  const transition = useMotiPressableTransition(({ pressed }) => {
     'worklet'
 
     if (pressed) {
@@ -60,6 +60,7 @@ const Item = () => {
       delay: 50,
     }
   })
+  
   const state = useMotiPressableState(({ pressed }) => {
     return {
       translateY: pressed ? -10 : 0,


### PR DESCRIPTION
I _believe_ this is a typo but could easily be mistaken

<img width="689" alt="image" src="https://user-images.githubusercontent.com/987654/235487809-4155bd64-5b52-48da-a84c-03df188da60c.png">
