### PR TITLE
Add `react-native` to peer dependencies

### DIFF
--- a/packages/moti/package.json
+++ b/packages/moti/package.json
@@ -47,6 +47,7 @@
     "expo-module": "expo-module"
   },
   "peerDependencies": {
+    "react-native": "*",
     "react-native-reanimated": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
`moti` imports `react-native` in its code. 

https://github.com/nandorojo/moti/blob/master/packages/moti/src/components/view.tsx#L1

According to the [rulebook](https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies) of yarn, all packages should list all of what they require/import in its dependencies/peerDependencies.

We add `react-native` to `moti`'s peerDependencies to resolve this problem.

(If not, the package might not work well when using Yarn 2+.)

