### PR TITLE
docs: fix broken link and remove misleading reanimated v2 mention

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -46,11 +46,11 @@ Moti `0.8.x` and higher requires at least Reanimated v2 stable (`2.0.0` or highe
 
 ### If you're using Expo
 
-Please follow the [Expo instructions](https://docs.expo.io/versions/latest/sdk/reanimated) for installing `react-native-reanimated` v2.
+Please follow the [Expo instructions](https://docs.expo.io/versions/latest/sdk/reanimated) for installing `react-native-reanimated`.
 
 ### If you aren't using Expo
 
-Please follow Reanimated's [installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) for v2.
+Please follow Reanimated's [installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation).
 
 ## Import Reanimated
 


### PR DESCRIPTION
The title of the section is _Install Reanimated 3+_ so it shouldn't mention v2.