### PR TITLE
docs: skeleton fixes

### DIFF
--- a/docs/docs/skeleton.mdx
+++ b/docs/docs/skeleton.mdx
@@ -57,7 +57,7 @@ Keep in mind you'll need to also install `expo-modules-core`. Please make sure y
 
 First, install the module resolver plugin:
 
-```npm2yarn
+```bash npm2yarn
 npm install babel-plugin-module-resolver
 ```
 

--- a/packages/moti/src/skeleton/skeleton-new.tsx
+++ b/packages/moti/src/skeleton/skeleton-new.tsx
@@ -5,7 +5,7 @@ import {
   useDerivedValue,
   useSharedValue,
 } from 'react-native-reanimated'
-import type Animated from 'react-native-reanimated'
+import type { SharedValue } from 'react-native-reanimated'
 
 import { View as MotiView } from '../components'
 import { MotiTransitionProp } from '../core'
@@ -113,7 +113,7 @@ const AnimatedGradient = React.memo(
     backgroundSize: number
     transition?: MotiTransitionProp
     show: boolean
-    measuredWidthSv: Animated.SharedValue<number>
+    measuredWidthSv: SharedValue<number>
   } & Pick<MotiSkeletonProps, 'Gradient'>) {
     return (
       <MotiView

--- a/packages/moti/src/skeleton/types.ts
+++ b/packages/moti/src/skeleton/types.ts
@@ -26,21 +26,25 @@ export type MotiSkeletonProps = {
    * </Skeleton>
    * ```
    *
+   * ```tsx
    * // skeleton will always show
    * <Skeleton show>
    *   {data ? <Data /> : null}
    * </Skeleton>
+   * ```
    *
+   * ```tsx
    * // skeleton will always hide
    * <Skeleton show={false}>
    *   {data ? <Data /> : null}
    * </Skeleton>
+   * ```
    *
-   * If you have multiple skeletons, you can use the `<Skeleton.Group show={loading} /> as a parent rather than use this prop directly.
+   * If you have multiple skeletons, you can use the `<Skeleton.Group show={loading} />` as a parent rather than use this prop directly.
    */
   show?: boolean
   /**
-   * Width of the skeleton. Defaults to `32` as the `minWidth`. Sets the container's `minWidth` to this value if defined, falling back to 32.
+   * Width of the skeleton. Defaults to `32` as the `minWidth`. Sets the container's `minWidth` to this value if defined, falling back to `32`.
    */
   width?: Size
   /**


### PR DESCRIPTION
- Fix npm2yarn toggle
- Fix `Skeleton` `show` prop comment examples
- Use `SharedValue` type instead of deprecated `Animated.SharedValue`