### PR TITLE
chore: move the description to the package `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "description": "The universal React Native animation library, powered by Reanimated 3. 🦉",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/moti/package.json
+++ b/packages/moti/package.json
@@ -1,5 +1,6 @@
 {
   "name": "moti",
+  "description": "The universal React Native animation library, powered by Reanimated 3. 🦉",
   "version": "0.29.0",
   "keywords": [
     "react-native",


### PR DESCRIPTION
# Why

Package description is not picked up correctly for the package, since the description is placed on workspace `package.json`, not on the actual published package.

# How

Move the `description` field from workspace to the package `package.json`.