### PR TITLE
Update `framer.com` URLs.

### DIFF
--- a/docs/docs/animations-overview.md
+++ b/docs/docs/animations-overview.md
@@ -73,7 +73,7 @@ If you set `type: 'spring'`, you can pass any options that Reanimated's `withSpr
 
 ## Mount/unmount animations 😎
 
-Framer Motion introduced the incredible [`AnimatePresence`](https://www.framer.com/api/motion/animate-presence/) component to animate a component before it unmounts.
+Framer Motion introduced the incredible [`AnimatePresence`](https://www.framer.com/motion/animate-presence/) component to animate a component before it unmounts.
 
 With Moti, you can now achieve the same thing in React Native.
 

--- a/packages/moti/src/core/types.ts
+++ b/packages/moti/src/core/types.ts
@@ -307,7 +307,7 @@ export interface MotiProps<
    *
    * **Important: you must wrap this component with the `AnimatePresence` component for exit animations to work.**
    *
-   * It follows the same API as the `exit` prop from `framer-motion`. Feel free to reference their docs: https://www.framer.com/api/motion/animate-presence/
+   * It follows the same API as the `exit` prop from `framer-motion`. Feel free to reference their docs: https://www.framer.com/motion/animate-presence/
    * */
   exit?:
     | AnimateWithTransforms


### PR DESCRIPTION
Looks like they removed the `/api/` part of the URLs.

Also, the `https://www.framer.com/api/motion/animate-presence/#animatepresenceprops.exitbeforeenter` URL that's also in the `animations-overview.md` also doesn't work anymore because the `exitbeforeenter` prop is deprecated: https://www.framer.com/motion/guide-upgrade/##animatepresence-exitbeforeenter-prop but I'm not sure what you want to do about this.