### PR TITLE
fix `motify()` type definition conflict for `transition` prop

### DIFF
--- a/packages/moti/src/core/motify.tsx
+++ b/packages/moti/src/core/motify.tsx
@@ -27,7 +27,7 @@ export default function motify<
   const withAnimations = () => {
     const Motified = forwardRef<
       Ref,
-      Props &
+      Omit<Props, keyof MotiProps<Animate>> &
         AnimatedProps<Props> &
         MotiProps<Animate> & {
           children?: React.ReactNode


### PR DESCRIPTION
Moti takes over the `transition` prop to define transition configs, but this might conflict with existing `transition` props on the original component.

While the implementation simply ignores passing `transition` to the original component, the type definition tries to merge the type declaration for both props, which sometimes results in impossible type intersections.

This change removes that possibility by omitting any `keyof MotiProps` from the component's original prop definition.