### PR TITLE
fix: safe-area-vew deprecation

### DIFF
--- a/docs/docs/api/motify.md
+++ b/docs/docs/api/motify.md
@@ -37,8 +37,9 @@ import {
   Text as RText,
   Image as RImage,
   ScrollView as RScrollView,
-  SafeAreaView as RSafeAreaView,
 } from 'react-native'
+
+import { SafeAreaView as RSafeAreaView } from 'react-native-safe-area-context'
 
 export const View = motify(RView)()
 export const Text = motify(RText)()

--- a/docs/docs/examples/dropdown.md
+++ b/docs/docs/examples/dropdown.md
@@ -9,14 +9,8 @@ You can preview this example [on Expo Snack](https://snack.expo.dev/@nandorojo/m
 
 ```tsx
 import React from 'react'
-import {
-  StyleSheet,
-  SafeAreaView,
-  View,
-  Text,
-  ViewProps,
-  Platform,
-} from 'react-native'
+import { StyleSheet, View, Text, ViewProps, Platform } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import {
   MotiPressable,
   useMotiPressable,

--- a/examples/sample/src/Moti.PressableMenu.tsx
+++ b/examples/sample/src/Moti.PressableMenu.tsx
@@ -1,14 +1,8 @@
 //  stitches,
 
-import {
-  StyleSheet,
-  SafeAreaView,
-  View,
-  Text,
-  ViewProps,
-  Platform,
-} from 'react-native'
+import { StyleSheet, View, Text, ViewProps, Platform } from 'react-native'
 import React from 'react'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import {
   MotiPressable,
   useMotiPressable,

--- a/packages/moti/package.json
+++ b/packages/moti/package.json
@@ -99,6 +99,7 @@
   },
   "gitHead": "36d489545d0a4e3b83af8650bdb9881a251fa777",
   "dependencies": {
-    "framer-motion": "^6.5.1"
+    "framer-motion": "^6.5.1",
+    "react-native-safe-area-context": "^5.6.2"
   }
 }

--- a/packages/moti/src/components/safe-area-view.tsx
+++ b/packages/moti/src/components/safe-area-view.tsx
@@ -1,4 +1,4 @@
-import { SafeAreaView as RSafeAreaView } from 'react-native'
+import { SafeAreaView as RSafeAreaView } from 'react-native-safe-area-context'
 
 import { motify } from '../core'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11533,6 +11533,11 @@ react-native-reanimated@3.11.0:
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
 
+react-native-safe-area-context@^5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz#283e006f5b434fb247fcb4be0971ad7473d5c560"
+  integrity sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==
+
 react-native@^0.74.1:
   version "0.74.7"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.74.7.tgz#68aef9bbfac7549eabfa3fe68ef4987489131188"


### PR DESCRIPTION
## Problem
React Native 0.81+ logs a deprecation warning when importing SafeAreaView from `react-native`:

```
Warning: SafeAreaView has been deprecated and will be removed in a future release. Please use 'react-native-safe-area-context' instead. See https://github.com/th3rdwave/react-native-safe-area-context`
```

## Solution
- Replaced deprecated SafeAreaView usage with `react-native-safe-area-context`
- No breaking changes
- Backwards compatible

## Tested
- Expo SDK 54
- React Native 0.81
- iOS + Android
